### PR TITLE
fix: correct Odoo 17 method signatures and guard against null lot_sto…

### DIFF
--- a/bhandar_griha/models/warehouse_dashboard.py
+++ b/bhandar_griha/models/warehouse_dashboard.py
@@ -42,7 +42,7 @@ class WarehouseDashboard(models.Model):
     @api.depends('product_id', 'warehouse_id')
     def _compute_stock_levels(self):
         for rec in self:
-            if rec.product_id and rec.warehouse_id:
+            if rec.product_id and rec.warehouse_id and rec.warehouse_id.lot_stock_id:
                 location = rec.warehouse_id.lot_stock_id
                 quants = self.env['stock.quant'].search([
                     ('product_id', '=', rec.product_id.id),

--- a/jana_seva_hrms/models/hr_onboarding.py
+++ b/jana_seva_hrms/models/hr_onboarding.py
@@ -53,8 +53,8 @@ class HrOnboardingTask(models.Model):
             self.write({'stage_id': done_stage.id, 'date_done': fields.Date.today()})
 
     @api.model
-    def _read_group_stage_ids(self, stages, domain, order=None):
-        return self.env['hr.onboarding.stage'].search([])
+    def _read_group_stage_ids(self, stages, domain, order):
+        return self.env['hr.onboarding.stage'].search([], order=order)
 
 
 class HrEmployee(models.Model):


### PR DESCRIPTION
…ck_id

1. jana_seva_hrms/models/hr_onboarding.py: Fix _read_group_stage_ids signature from (self, stages, domain, order=None) to (self, stages, domain, order). In Odoo 17 the group_expand callback always receives all four positional arguments; the optional default caused "takes 3 positional arguments but 4 were given". Also pass order through to the search so kanban stages respect the configured sequence.

2. bhandar_griha/models/warehouse_dashboard.py: Add rec.warehouse_id.lot_stock_id guard to _compute_stock_levels. When a warehouse has no stock location configured lot_stock_id is False, making child_of False raise a PostgreSQL error during the stored-field recompute. That compute failure leaves current_stock / reserved_qty / available_qty and is_below_reorder with NULL values, which the OWL client cannot resolve and reports as "product_id field is undefined" when it tries to evaluate the decoration-danger expression that depends on the broken field chain. The guard falls through to the 0.0 defaults instead of crashing.

https://claude.ai/code/session_011XSUdTfGck3ECvjyXSHhMX